### PR TITLE
refactor(grid): `if`-`return` rules -> `matches!`

### DIFF
--- a/src/grid.rs
+++ b/src/grid.rs
@@ -52,15 +52,8 @@ impl Grid {
             }
         }
 
-        // Rules (from wikipedia)
-        if cell.is_alive() && (num_neighbour_alive == 2 || num_neighbour_alive == 3) {
-            return true; // alive
-        }
-        if !cell.is_alive() && num_neighbour_alive == 3 {
-            return true;
-        }
-
-        false
+        // Rules (from Wikipedia)
+        matches!((cell.is_alive(), num_neighbour_alive), (true, 2 | 3) | (false, 3))
     }
     pub fn update(&mut self) {
         // Vector of next states. It will match by index


### PR DESCRIPTION
The `matches` macro makes it much simpler, and ensures that if `is_alive` method ever becomes impure (for some reason) then the checking will always be "atomic" (order-agnostic)